### PR TITLE
[AC-144] Add POC for cron schedule

### DIFF
--- a/Docker/.env.template
+++ b/Docker/.env.template
@@ -1,0 +1,4 @@
+AdminApiSettings__ApiUrl=localhost:8080/api
+AdminApiSettings__AdminConsoleInstancesURI=localhost:8080/instances
+AdminApiSettings__AdminConsoleHealthCheckURI=localhost:8080/health
+AdminApiSettings__AccessTokenUrl=localhost:8080/connect/token

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,3 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
 # Image based on .NET SDK to compile and publish the application
 
 FROM mcr.microsoft.com/dotnet/sdk:8.0.401-alpine3.20@sha256:658c93223111638f9bb54746679e554b2cf0453d8fb7b9fed32c3c0726c210fe AS build
@@ -27,9 +32,8 @@ RUN apt-get update && apt-get install -y cron
 # Add cron from file and adjust permissions
 COPY crontab /etc/cron.d/container_cronjob
 
-RUN chmod 0644 /etc/cron.d/container_cronjob
-
-RUN crontab /etc/cron.d/container_cronjob
+RUN chmod 0644 /etc/cron.d/container_cronjob &&\
+    crontab /etc/cron.d/container_cronjob
 
 
 WORKDIR /app

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,24 +1,41 @@
-# SPDX-License-Identifier: Apache-2.0
-# Licensed to the Ed-Fi Alliance under one or more agreements.
-# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
-# See the LICENSE and NOTICES files in the project root for more information.
-
 # Image based on .NET SDK to compile and publish the application
+
 FROM mcr.microsoft.com/dotnet/sdk:8.0.401-alpine3.20@sha256:658c93223111638f9bb54746679e554b2cf0453d8fb7b9fed32c3c0726c210fe AS build
+
 WORKDIR /source
+
 
 # Copy source code and compile the application
 COPY Application/EdFi.AdminConsole.HealthCheckService/. ./EdFi.AdminConsole.HealthCheckService/
+
 WORKDIR /source/EdFi.AdminConsole.HealthCheckService
+
+
 
 # Restore dependencies, Then build and publish release
 RUN dotnet restore &&\
-    dotnet publish -c Release -o /app
+  dotnet publish -c Release -o /app
+
 
 # .NET Runtime image to execute the application
-FROM mcr.microsoft.com/dotnet/runtime:8.0.11-alpine3.20-amd64@sha256:6970cb2d1f8ba6e87d49cfb35687106f0b80c874171978b60d8962daaa8e097f AS runtime
+
+FROM mcr.microsoft.com/dotnet/runtime:8.0.11 AS runtime
+
+# Install Cron.
+RUN apt-get update && apt-get install -y cron
+
+# Add cron from file and adjust permissions
+COPY crontab /etc/cron.d/container_cronjob
+
+RUN chmod 0644 /etc/cron.d/container_cronjob
+
+RUN crontab /etc/cron.d/container_cronjob
+
+
 WORKDIR /app
+
+# Add Published executable
 COPY --from=build /app .
 
-# Execute the app
-ENTRYPOINT ["dotnet", "EdFi.AdminConsole.HealthCheckService.dll"]
+# Execute the app via chron
+CMD ["cron", "-f"]

--- a/Docker/health-check-svc.yml
+++ b/Docker/health-check-svc.yml
@@ -1,0 +1,15 @@
+version: "3.9"
+
+services:
+  health-check-service:
+    build:
+      context: ../
+      dockerfile: Docker/Dockerfile
+    volumes:
+      - service-logs:/var/log/achealthsvc.log
+    env_file:
+      - .env
+
+volumes:
+  service-logs:
+    name: health-check-service-logs

--- a/Docker/health-check-svc.yml
+++ b/Docker/health-check-svc.yml
@@ -1,4 +1,7 @@
-version: "3.9"
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
 
 services:
   health-check-service:
@@ -7,8 +10,6 @@ services:
       dockerfile: Docker/Dockerfile
     volumes:
       - service-logs:/var/log/achealthsvc.log
-    env_file:
-      - .env
 
 volumes:
   service-logs:

--- a/crontab
+++ b/crontab
@@ -1,0 +1,2 @@
+* * * * * root dotnet /app/EdFi.AdminConsole.HealthCheckService.dll >> /var/log/achealthsvc.log
+# TEST write Application output to achealthsvc.log every minute


### PR DESCRIPTION
Provides a POC for Spinning up the Health Check Service locally and running on a cron schedule.